### PR TITLE
NCL tools page (at cyberhawks.org/resources/ncl-tools)

### DIFF
--- a/_resources/ncl-tools.md
+++ b/_resources/ncl-tools.md
@@ -1,0 +1,34 @@
+---
+title: NCL Challenge Tools
+layout: post
+---
+
+- [Template for NCL Team Game Spreadsheet](https://docs.google.com/spreadsheets/d/1LbWelsiOC644HMjEbczUHIytiA-4EeqH/copy)  
+  Helps you calculate team game certainty
+
+- [hashes.com](hashes.com)  
+  Searchable index/portal for identifying and looking up recovered plaintexts for many hash values (hash type detection + searchable database).
+
+- [cyberchef.org](cyberchef.org)  
+  “Cyber Swiss Army Knife”: browser-based toolkit for encoding/decoding, encryption, parsing and data transformations.
+
+- [Aperi’Solve](aperisolve.com)  
+  Web platform for automated steganalysis/layer analysis of images (uses tools like zsteg, exiftool, binwalk, etc.).
+
+- [wigle.net](wigle.net)  
+  Wi-Fi/cell hotspot mapping database (wardriving dataset you can query to find SSIDs, MACs and geo coordinates).
+
+- [Overpass](https://overpass-turbo.eu/)  
+  Web editor/runner for Overpass API queries against OpenStreetMap (filter & visualize OSM data).
+
+- [SunCalc](https://www.suncalc.org/)  
+  Interactive sun-position/solar-phase calculator (sunrise/sunset, azimuth, altitude, shadow lengths for any place/time).
+
+- [pwntools](docs.pwntools.com)  
+  Python CTF/exploit-development library for rapid prototyping of network/local exploits and interacting with binaries/remote services.
+
+- pwndbg  
+  GDB/LLDB plugin that enhances low-level debugging with nicer displays and convenience commands for reverse-engineering and exploit dev.
+
+
+Do you want me to also format the descriptions as sub-bullets instead of inline text?

--- a/_resources/ncl-tools.md
+++ b/_resources/ncl-tools.md
@@ -27,5 +27,5 @@ layout: post
 - [pwntools](docs.pwntools.com)  
   Python CTF/exploit-development library for rapid prototyping of network/local exploits and interacting with binaries/remote services.
 
-- pwndbg  
+- [pwndbg](https://github.com/pwndbg/pwndbg)  
   GDB/LLDB plugin that enhances low-level debugging with nicer displays and convenience commands for reverse-engineering and exploit dev.

--- a/_resources/ncl-tools.md
+++ b/_resources/ncl-tools.md
@@ -29,6 +29,3 @@ layout: post
 
 - pwndbg  
   GDB/LLDB plugin that enhances low-level debugging with nicer displays and convenience commands for reverse-engineering and exploit dev.
-
-
-Do you want me to also format the descriptions as sub-bullets instead of inline text?


### PR DESCRIPTION
A webpage for NCL game players to have an easy way to view and access the tools talked about in today's meeting

Website rendered view:
<img width="521" height="649" alt="Screenshot 2025-09-17 at 1 42 33 PM" src="https://github.com/user-attachments/assets/b2f5e125-0620-4cbe-b127-d4455d106367" />